### PR TITLE
fixed error case for users post endpoint that was hanging

### DIFF
--- a/routes/api.ts
+++ b/routes/api.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 
 const express = require('express');
 const router = express.Router();
@@ -13,8 +13,8 @@ router.get('/users', (req: Request, res: Response) =>{
     })
 })
 
-router.post('/users', (req: Request, res: Response) =>{
-    const newUser = {
+router.post('/users', (req: Request, res: Response, next: NextFunction) =>{
+        const newUser = {
         uuid: req.body.uuid,
         userName: req.body.userName,
         password: req.body.password,
@@ -22,6 +22,9 @@ router.post('/users', (req: Request, res: Response) =>{
     }
     User.create(newUser).then(function(user: FIX_ME){
         res.send(user);
+    }).catch((e:any) => {
+        console.log(e);
+        next(e)
     })
 })
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -77,21 +77,21 @@ describe('user routes', () =>{
             expect(res2.body[3].preferredPaymentMethod).toBe('CASH')
         })
 
-        // //ATM UUID is passed in with making a post request, but should change this so a UUID is generated for the user
-        // it('should throw an error if uuid, username, password is omitted', () =>{
-        //     try{  
-        //         const res = request
-        //         .post('/api/users')
-        //         .send({
-        //             uuid: '6',
-        //             password: 'testPassF'
-        //         })
-        //     }
-        //     catch(err){
-        //         request.close()
-        //         expect(err.message).toBe('userName required')
-        //     }
-        // })
+         //ATM UUID is passed in with making a post request, but should change this so a UUID is generated for the user
+         it('should throw an error if uuid, username, password is omitted', async () =>{
+             try{  
+                 const res = await request
+                 .post('/api/users')
+                 .send({
+                     uuid: '6',
+                     password: 'testPassF'
+                 })
+             }
+             catch(err){
+                 request.close()
+                 expect(err.message).toBe('userName required')
+             }
+         })
 
         it('should not take in any extra information past User Schema', async () =>{
             const res = await request


### PR DESCRIPTION
the endpoint is suppose to throw (expected in unit tests) but promise rejection did not pass context to the next middleware (calling next with the error) 