### PR TITLE
[bug-42] Fix logging db failure exceptions

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -13,8 +13,6 @@ app.use('/api', routes);
 
 //error handeling
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {
-  console.error(err)
-  console.error(err.stack)
   res.status(err.status || 500).send(err.message || 'Internal server error.')
 })
 

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ const init = () =>{
             app.listen(PORT,()=> console.log(`Listening on port ${PORT}`));
         })
     } catch(e){
-        console.log(e)
+        throw(e);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "description": "A billsplitting mobile app",
   "scripts": {
-    "test": "jest ",
+    "test": "jest",
     "start-dev": "nodemon index.ts",
     "seed": "node seed"
   },

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -23,7 +23,6 @@ router.post('/users', (req: Request, res: Response, next: NextFunction) =>{
     User.create(newUser).then(function(user: FIX_ME){
         res.send(user);
     }).catch((e:any) => {
-        console.log(e);
         next(e)
     })
 })

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -31,6 +31,7 @@ describe('user routes', () =>{
     afterAll(() => {
         disconnectDatabase();
     });
+
     describe('GET route', () =>{
         it('should get all users from database', async () =>{
             const res = await request.get('/api/users');

--- a/utils/test-utils/db.util.js
+++ b/utils/test-utils/db.util.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 
 let mongo = new MongoMemoryServer;
-jest.setTimeout(60000);
 
 const connectDatabase = async () => {
   try {
@@ -16,8 +15,7 @@ const connectDatabase = async () => {
 
     await mongoose.connect(uri, mongooseOpts);
   } catch(error) {
-    console.log(error);
-    process.exit(1);
+    throw(error);
   }
 }
 
@@ -28,8 +26,7 @@ const disconnectDatabase = async () => {
     await mongo.stop();
     mongo = null;
   } catch(error) {
-    console.log(error);
-    process.exit(1);
+    throw(error);
   }
 };
 


### PR DESCRIPTION
## Description
We are currently logging a couple of exceptions which can be cluttered and unnecessary as we are already throwing the exceptions. For instance, when running unit tests for users, we have a invalid test case where we throw an error if required fields are not passed. This results in the entire error stack trace getting printed, which can be misleading while running the unit tests because logically there is an error, but overall unit tests succeed because we expect there to be an error.

Rid the console logging as they are not useful and error should be present in the errors thrown.

[#42](https://github.com/tally-team/tally-backend/issues/42)

## How Has This Been Tested?
Ran unit tests; no longer sees the stacktrace:
```
michellelam@Michelles-Air tally-backend % npm run test

> tally-backend@1.0.0 test
> jest

 PASS  test/user.test.js (5.032 s)
  user routes
    GET route
      ✓ should get all users from database (601 ms)
    POST route
      ✓ should add a new user to the database (60 ms)
      ✓ should automatically add the default attribute for 'preferredPaymentMethod' if omitted (34 ms)
      ✓ should throw an error if uuid, username, password is omitted (31 ms)
      ✓ should not take in any extra information past User Schema (29 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        5.11 s, estimated 6 s
Ran all test suites.
```