### PR TITLE
[chore] Add functionality for associating issues that are blocked by its dependecies

### DIFF
--- a/.github/workflows/blocking-issues.yml
+++ b/.github/workflows/blocking-issues.yml
@@ -1,0 +1,17 @@
+name: Blocking Issues
+
+on: 
+  issues:
+    types: [opened, edited, deleted, transferred, closed, reopened]
+  pull_request_target: 
+    types: [opened, edited, closed, reopened]
+    
+jobs: 
+  blocking_issues: 
+    runs-on: ubuntu-latest
+    name: Checks for blocking issues
+    
+    steps: 
+      - uses: Levi-Lesches/blocking-issues@v2
+        with: 
+          use-label: "blocked issue"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,17 @@
+name: "Blocking Issues"
+description: "Labels issues and PRs when they're blocked"
+inputs: 
+  token: 
+    description: "The GitHub token to use. Make sure to use a Personal Access Token, so PRs can be updated." 
+    required: false
+    default: ${{ github.token }}
+  use-label: 
+    description: "The name of the label to apply to blocked issues or pull requests. If not found, the default value will be used."
+    required: false
+    default: "blocked"
+branding: 
+  icon: "git-pull-request"
+  color: "red"
+runs:
+  using: 'node16'
+  main: 'src/index.js'


### PR DESCRIPTION
## Description
There are issues that have dependencies but are not labelled as "blocked" due to the limitations of Github's functionalites. [It seems like there is no official workaround at the moment](https://github.com/orgs/community/discussions/4928) but there is, however, a solution someone has come up with: [blocking issues](https://github.com/Levi-Lesches/blocking-issues).

When an issue is open, the action check for whether the following text is present in the description (`Blocked by #X, #Y, #Z`) and will be marked as blocked. See example here: https://github.com/Levi-Lesches/blocking-issues-test/issues/23

When the issue closes, there will be a check in other PRs that depend on this issue and updates them. [See example](https://github.com/Levi-Lesches/blocking-issues-test/pull/25).

## How Has This Been Tested?
N/A, will test after this PR is merged in by labelling tickets as blocked. 
