### PR TITLE
[chore] Pin specific node and npm version in engine of package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 18.16.1
+          npm-version: 9.5.1
       - name: Install dependencies
         run: npm ci
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "ts-node": "^10.7.0"
   },
   "engines": {
-    "npm": "^9.5.1",
-    "node": "^18.16.1"
+    "npm": "9.5.1",
+    "node": "18.16.1"
   },
   "lint-staged": {
     "*.{ts, js}": "eslint --fix",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "ts-node": "^10.7.0"
   },
   "engines": {
-    "npm": "9.5.1",
-    "node": "18.16.1"
+    "npm": "^9.5.1",
+    "node": "^18.16.1"
   },
   "lint-staged": {
     "*.{ts, js}": "eslint --fix",


### PR DESCRIPTION
## Description
[CI build keeps failing](https://github.com/tally-team/tally-backend/actions/runs/7981720837/job/21794170306?pr=69) due to unpinned version in build.yaml:
```
npm ERR! notsup Required: {"npm":"^9.5.1","node":"^18.16.1"}
npm ERR! notsup Actual:   {"npm":"10.2.3","node":"v18.1[9](https://github.com/tally-team/tally-backend/actions/runs/7981720837/job/21794170306?pr=69#step:4:10).0"}
```

We define the node version as `18.x`, which fetches the latest version within 18, and did not define npm, which will fetch the latest version (i.e. 10.2.3), causing the incompatible types.

## How Has This Been Tested?
[Install dependency task succeeds.](https://github.com/tally-team/tally-backend/actions/runs/7982800114/job/21796902032)
